### PR TITLE
Remove AMI logic

### DIFF
--- a/examples/basic-windows/main.tf
+++ b/examples/basic-windows/main.tf
@@ -41,7 +41,6 @@ module "some_windows_server" {
   source                        = "../../"
   instance_type                 = "t3.2xlarge"
   ami                           = "ami-07dcc3822b6f2bdbe" #Windows 2016 Base
-  ami_owner                     = "801119661308"
   security_groups               = [aws_security_group.servers.id]
   delete_on_termination         = true
   ssh_key_pair                  = "prototype"

--- a/examples/complete/fixtures.us-west-1.tfvars
+++ b/examples/complete/fixtures.us-west-1.tfvars
@@ -17,3 +17,5 @@ instance_type = "t2.micro"
 allowed_ports = [22, 80, 443]
 
 ssh_public_key_path = "/secrets"
+
+ami = "ami-013f17f36f8b1fefb" # Ubuntu Server 18.04 LTS

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -45,4 +45,5 @@ module "ec2_instance" {
   associate_public_ip_address = var.associate_public_ip_address
   instance_type               = var.instance_type
   allowed_ports               = var.allowed_ports
+  ami                         = var.ami
 }

--- a/variables.tf
+++ b/variables.tf
@@ -104,14 +104,7 @@ variable "availability_zone" {
 
 variable "ami" {
   type        = string
-  description = "The AMI to use for the instance. By default it is the AMI provided by Amazon with Ubuntu 16.04"
-  default     = ""
-}
-
-variable "ami_owner" {
-  type        = string
-  description = "Owner of the given AMI (ignored if `ami` unset)"
-  default     = ""
+  description = "The AMI to use for the instance."
 }
 
 variable "ebs_optimized" {


### PR DESCRIPTION
I don't want this logic in here. Otherwise when a Windows AMI that we
use is marked private by the owner (in this case Amazon), the plan
errors and does not let me proceed. If I do specify an existing AMI ID,
it forces the instance to be replaced...NOT ideal.

While this does remove some of the helpful logic, I see it doing more
harm than good.