### PR TITLE
replace deprecated null_data_source

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -9,7 +9,7 @@ locals {
     var.associate_public_ip_address
     && var.assign_eip_address
     && var.instance_enabled
-    ? local.computed_dns # TODO; Ask about why this was done
+    ? local.computed_dns
     : join("", aws_instance.default.*.public_dns)
   )
 }
@@ -92,6 +92,17 @@ resource "aws_instance" "default" {
   }
 
   tags = module.label.tags
+
+  lifecycle {
+    # Prevent changes to the ami (due to use of data.aws_ami for example)
+    # from accidentally re-creating the instance.
+    # Also ignore changes to user_data, to not implicitly delete the instance
+    # because additional info was added to user_data at a later point
+    ignore_changes = [
+      ami,
+      user_data,
+    ]
+  }
 }
 
 resource "aws_eip" "default" {

--- a/outputs.tf
+++ b/outputs.tf
@@ -60,3 +60,8 @@ output "primary_network_interface_id" {
   description = "ID of the instance's primary network interface"
   value       = join("", aws_instance.default.*.primary_network_interface_id)
 }
+
+output "ami" {
+  value       = join("", aws_instance.default.*.ami)
+  description = "The AMI used to create the EC2 instance"
+}


### PR DESCRIPTION
The plan is to label this 1.1.0, since the lifecycle changes technically are a breaking change.

- The `null_data_source` resource has been deprecated.
  - Refactored code to use locals instead
  - Removed `null_data_source`
  - Reports of this being deprecated exist since feb 2021, but i was unable to pinpoint the exact version this took effect in terraform.
- Ignore `ami` and `user_data` changes so that instances are not implicitly re-created when dynamic AMI references are used, or `user_data` was changed to document additional instructions for the future.
- output the ami that is in use, not the one that is passed in.